### PR TITLE
Ownership of build path set to shell user/group

### DIFF
--- a/providers/make.rb
+++ b/providers/make.rb
@@ -31,8 +31,8 @@ action :install do
 
       # Ensure the build_path directory is present.
       directory @new_resource.build_path do
-        owner "root"
-        group "root"
+        owner new_resource.shell_user
+        group new_resource.shell_group
         mode "0755"
         recursive true
         action :create


### PR DESCRIPTION
The drush make operation will fail if run with other user than root, because of permissions on build path.
Both resources on this provider should be coordinated.
